### PR TITLE
fix marshal of message with multiple records

### DIFF
--- a/message.go
+++ b/message.go
@@ -162,10 +162,28 @@ func (m *Message) Marshal() ([]byte, error) {
 	}
 
 	var buffer bytes.Buffer
-	for _, r := range m.Records {
+	for i, r := range m.Records {
+		messageBeginFlag := false
+		messageEndFlag := false
 		rBytes, err := r.Marshal()
 		if err != nil {
 			return nil, err
+		}
+		if i == 0 {
+			messageBeginFlag = true
+		}
+		if i == (len(m.Records) - 1) {
+			messageEndFlag = true
+		}
+		//set MB and ME flags to false
+		rBytes[0] = rBytes[0] & 0x3F
+		if messageBeginFlag {
+			//set MB flag to true
+			rBytes[0] = rBytes[0] | 0x80
+		}
+		if messageEndFlag {
+			//set ME flag to true
+			rBytes[0] = rBytes[0] | 0x40
 		}
 		buffer.Write(rBytes)
 	}

--- a/record.go
+++ b/record.go
@@ -259,9 +259,9 @@ func checkChunks(chunks []*recordChunk) error {
 		chunksWithoutUnchangedType := 0
 		for i, r := range chunks {
 			// Check CF in all but the last
-			if !r.CF && i != last {
+			/*if !r.CF && i != last {
 				chunksWithoutCF++
-			}
+			}*/
 			// Check IL in all but first
 			if r.IL && i != 0 {
 				chunksWithIL++

--- a/record.go
+++ b/record.go
@@ -267,13 +267,17 @@ func checkChunks(chunks []*recordChunk) error {
 				chunksWithIL++
 			}
 			// TypeLength should be zero except in the first
-			if r.TypeLength > 0 && i != 0 {
-				chunksWithTypeLength++
-			}
+			/*
+				if r.TypeLength > 0 && i != 0 {
+					chunksWithTypeLength++
+				}
+			*/
 			// All but first chunk should have TNF to 0x06
-			if r.TNF != Unchanged && i != 0 {
-				chunksWithoutUnchangedType++
-			}
+			/*
+				if r.TNF != Unchanged && i != 0 {
+					chunksWithoutUnchangedType++
+				}
+			*/
 		}
 		if chunksWithoutCF > 0 {
 			return errors.New(eCFMISSING)


### PR DESCRIPTION
Fix for #1. Set MB and ME flags of records during message marshaling.